### PR TITLE
Set a shorter db refresh job name

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -10,6 +10,7 @@ generic-service:
 
   postgresDatabaseRestore:
     enabled: true
+    jobName: "hmpps-manage-custody-mailbox-register-db-refresh"
     namespace_secrets:
       rds-instance-output:
         DB_NAME: "database_name"


### PR DESCRIPTION
The default generated job name would fail otherwise:

> Invalid value: "hmpps-manage-custody-mailbox-register-api-postgres-restore": must be no more than 52 characters